### PR TITLE
Change build settings for 1.20.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.4
-yarn_mappings=1.20.4+build.3
-loader_version=0.15.7
+minecraft_version=1.20.1
+yarn_mappings=1.20.1+build.10
+loader_version=0.15.11
 
 # Mod Properties
 mod_version=1.0.1
@@ -14,4 +14,4 @@ maven_group=me.dienes.abseil
 archives_base_name=abseil
 
 # Dependencies
-fabric_version=0.96.4+1.20.4
+fabric_version=0.92.2+1.20.1

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.15.7",
-		"minecraft": "~1.20.4",
+		"minecraft": "~1.20.1",
 		"java": ">=17",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
I tweaked the build just enough to build under 1.20.1. There don't seem to be any dependencies on 1.20.4+ features. It builds and all of the functionality seems to work. I'd like to put this in a 1.20.1 modpack if possible.